### PR TITLE
Corrected double braces in "Escaping Braces" section

### DIFF
--- a/_posts/2012-10-10-python-string-format.md
+++ b/_posts/2012-10-10-python-string-format.md
@@ -137,7 +137,7 @@ Hat tip to [earthboundkids][2] who provided this on reddit.
 If you need to use braces when using str.format(), just double up
 
 ```python
-print(" The {} set is often represented as {% raw %}{{{0}}{% endraw %}".format("empty"))
+print(" The {} set is often represented as {% raw %}{{0}}{% endraw %}".format("empty"))
 ~~ The empty set is often represented as {0}
 ```
 


### PR DESCRIPTION
I love this post as a resource for string formatting and noticed that when formatted, the braces in the "Escaping Braces" section is unbalanced. 